### PR TITLE
Use allow-list for whether to insert NFC polling frames.

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/multipaz/identityreader/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/multipaz/identityreader/Platform.android.kt
@@ -5,15 +5,37 @@ import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.android.Android
 import org.multipaz.context.applicationContext
 import org.multipaz.context.getActivity
+import org.multipaz.util.Logger
+
+private const val TAG = "Platform"
 
 class AndroidPlatform : Platform {
     override val name: String = "Android ${Build.VERSION.SDK_INT}"
+
+    override val nfcPollingFramesInsertionSupported by lazy {
+        // Use an allow-list until b/460804407 is resolved and used in Multipaz
+        if (Build.MANUFACTURER == "Google" && (
+                    Build.MODEL.startsWith("Pixel 8") ||
+                    Build.MODEL.startsWith("Pixel 9") ||
+                    Build.MODEL.startsWith("Pixel 10") ||
+                    Build.MODEL.startsWith("Pixel 11")
+            )
+        ) {
+            Logger.i(TAG, "Device is on allow-list for nfcPollingFramesInsertionSupported")
+            true
+        } else {
+            Logger.w(TAG, "Device is not allow-list for nfcPollingFramesInsertionSupported")
+            false
+        }
+    }
 
     override fun exitApp() {
         System.exit(0)
     }
 }
 
-actual fun getPlatform(): Platform = AndroidPlatform()
+private val platform by lazy { AndroidPlatform() }
+
+actual fun getPlatform(): Platform = platform
 
 actual fun platformHttpClientEngineFactory(): HttpClientEngineFactory<*> = Android

--- a/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/DeveloperSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/DeveloperSettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Bluetooth
 import androidx.compose.material.icons.outlined.DoorBack
+import androidx.compose.material.icons.outlined.Nfc
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -105,6 +106,33 @@ information
                             checked = settingsModel.bleL2capInEngagementEnabled.collectAsState().value,
                             onCheckedChange = { value ->
                                 settingsModel.bleL2capInEngagementEnabled.value = value
+                            },
+                        )
+                    }
+                }
+
+                entries.add {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.Start),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            modifier = Modifier.size(32.dp),
+                            imageVector = Icons.Outlined.Nfc,
+                            contentDescription = null
+                        )
+                        EntryItem(
+                            modifier = Modifier.weight(1.0f),
+                            key = "Insert extra frames in NFC polling loop",
+                            valueText = "If enabled, extra frames will be inserted " +
+                                    "to enable the wallet to detect this is an Identity Reader"
+                        )
+                        Checkbox(
+                            enabled = getPlatform().nfcPollingFramesInsertionSupported,
+                            checked = settingsModel.insertNfcPollingFrames.collectAsState().value &&
+                                    getPlatform().nfcPollingFramesInsertionSupported,
+                            onCheckedChange = { value ->
+                                settingsModel.insertNfcPollingFrames.value = value
                             },
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/Platform.kt
@@ -5,6 +5,9 @@ import io.ktor.client.engine.HttpClientEngineFactory
 interface Platform {
     val name: String
 
+    // Workaround for now until b/460804407 is resolved and used in Multipaz
+    val nfcPollingFramesInsertionSupported: Boolean
+
     fun exitApp()
 }
 

--- a/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/SettingsModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/SettingsModel.kt
@@ -149,6 +149,7 @@ class SettingsModel private constructor(
         // L2CAP is off by default for now because Apple Wallet's L2CAP implementation is buggy.
         bind(bleL2capEnabled, "bleL2capEnabled", false)
         bind(bleL2capInEngagementEnabled, "bleL2capInEngagementEnabled", true)
+        bind(insertNfcPollingFrames, "insertNfcPollingFrames", true)
     }
 
     val logTransactions = MutableStateFlow<Boolean>(false)
@@ -165,4 +166,5 @@ class SettingsModel private constructor(
     val devMode = MutableStateFlow<Boolean>(false)
     val bleL2capEnabled = MutableStateFlow<Boolean>(false)
     val bleL2capInEngagementEnabled = MutableStateFlow<Boolean>(false)
+    val insertNfcPollingFrames = MutableStateFlow<Boolean>(true)
 }

--- a/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/StartScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/multipaz/identityreader/StartScreen.kt
@@ -326,9 +326,13 @@ private fun StartScreenWithPermissions(
     )
 
     val reader = NfcTagReader.getReaders().firstOrNull()
-    val nfcScanOptions = NfcScanOptions(
-        pollingFrameData = ByteString("6a0281030000".fromHex())
-    )
+    val nfcScanOptions = if (getPlatform().nfcPollingFramesInsertionSupported && settingsModel.insertNfcPollingFrames.value) {
+        NfcScanOptions(
+            pollingFrameData = ByteString("6a0281030000".fromHex())
+        )
+    } else {
+        NfcScanOptions()
+    }
     // On Platforms that support NFC scanning without a dialog, start scanning as soon
     // as we enter this screen. We'll get canceled when switched away because `coroutineScope`
     // will get canceled.

--- a/composeApp/src/iosMain/kotlin/org/multipaz/identityreader/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/multipaz/identityreader/Platform.ios.kt
@@ -8,11 +8,16 @@ import platform.posix.exit
 class IOSPlatform: Platform {
     override val name: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
 
+    // No API to do this on iOS
+    override val nfcPollingFramesInsertionSupported = false
+
     override fun exitApp() {
         exit(0)
     }
 }
 
-actual fun getPlatform(): Platform = IOSPlatform()
+private val platform by lazy { IOSPlatform() }
+
+actual fun getPlatform(): Platform = platform
 
 actual fun platformHttpClientEngineFactory(): HttpClientEngineFactory<*> = Darwin


### PR DESCRIPTION
It turns out that if this feature is used and the device doesn't support it then Android's NfcAdapter.enableReaderMode() silently fails. I've asked for NfcAdapter.isReaderModeAnnotationSupported() to be available as public API (it's currently behind a flag), until this is done just use a white-list of devices where we know this works.

Also add UI to Developer Settings for whether to insert polling frames, if supported.

Test: Manually tested.